### PR TITLE
Feature/#3

### DIFF
--- a/domain/src/main/java/way/application/domain/firebase/FirebaseNotificationDomain.java
+++ b/domain/src/main/java/way/application/domain/firebase/FirebaseNotificationDomain.java
@@ -29,10 +29,17 @@ public class FirebaseNotificationDomain {
 	private final String API_URL = "https://fcm.googleapis.com/v1/projects/whereareyou-34289/messages:send";
 	private final ObjectMapper objectMapper;
 
-	public void sendNotification(MemberEntity invitedMember, MemberEntity createMember) {
+	/**
+	 * @param targetMemberEntity
+	 * @param sendMemberEntity
+	 *
+	 * sendMemberEntity -> targetMemberEntity 에게 푸시 알림 보내기
+	 * 추후 친구 추가와 관련된 로직의 경우 하드 코딩되어 있는 푸시 알림 메세지 Constant 변수로 수정하여 인자로 입력
+	 */
+	public void sendNotification(MemberEntity targetMemberEntity, MemberEntity sendMemberEntity) {
 		try {
-			String body = createMember.getUserName() + "이(가) 일정 초대를 했습니다.";
-			sendMessageTo(invitedMember.getFireBaseTargetToken(), "일정 요청이 들어왔습니다.", body);
+			String body = sendMemberEntity.getUserName() + "이(가) 일정 초대를 했습니다.";
+			sendMessageTo(targetMemberEntity.getFireBaseTargetToken(), "일정 요청이 들어왔습니다.", body);
 		} catch (IOException e) {
 			throw new ServerException(ErrorResult.FIREBASE_CLOUD_MESSAGING_EXCEPTION);
 		}

--- a/domain/src/main/java/way/application/domain/member/MemberDomain.java
+++ b/domain/src/main/java/way/application/domain/member/MemberDomain.java
@@ -11,6 +11,13 @@ import way.application.infrastructure.member.entity.MemberEntity;
 @Component
 public class MemberDomain {
 
+	/**
+	 * @param createMemberEntity
+	 * @param invitedMemberEntity
+	 *
+	 * 일정 추가 시 일정에 들어가는 MemberEntity 구성
+	 * create(일정 생성자) + invited(일정 초대자) Set 구성 후 반환
+	 */
 	public Set<MemberEntity> createMemberSet(MemberEntity createMemberEntity, List<MemberEntity> invitedMemberEntity) {
 		Set<MemberEntity> totalMemberEntity = new HashSet<>(invitedMemberEntity);
 		totalMemberEntity.add(createMemberEntity);
@@ -18,7 +25,14 @@ public class MemberDomain {
 		return totalMemberEntity;
 	}
 
-	public boolean checkIsCreator(MemberEntity invitedMember, MemberEntity createMemberEntity) {
-		return invitedMember.getMemberSeq().equals(createMemberEntity.getMemberSeq());
+	/**
+	 * @param invitedMemberEntity
+	 * @param createMemberEntity
+	 *
+	 * 일정 초대자 <-> 일정 생성자 동일 여부 확인
+	 * Seq 값 비교 처리
+	 */
+	public boolean checkIsCreator(MemberEntity invitedMemberEntity, MemberEntity createMemberEntity) {
+		return invitedMemberEntity.getMemberSeq().equals(createMemberEntity.getMemberSeq());
 	}
 }

--- a/infrastructure/src/main/java/way/application/infrastructure/member/repository/MemberRepository.java
+++ b/infrastructure/src/main/java/way/application/infrastructure/member/repository/MemberRepository.java
@@ -1,0 +1,10 @@
+package way.application.infrastructure.member.repository;
+
+import java.util.List;
+
+import way.application.infrastructure.member.entity.MemberEntity;
+
+public interface MemberRepository {
+	MemberEntity validateMemberSeq(Long memberSeq);
+	List<MemberEntity> validateMemberSeqs(List<Long> memberSeqs);
+}

--- a/infrastructure/src/main/java/way/application/infrastructure/member/repository/MemberRepositoryImpl.java
+++ b/infrastructure/src/main/java/way/application/infrastructure/member/repository/MemberRepositoryImpl.java
@@ -1,0 +1,37 @@
+package way.application.infrastructure.member.repository;
+
+import java.util.Collections;
+import java.util.List;
+
+import org.springframework.stereotype.Component;
+
+import lombok.RequiredArgsConstructor;
+import way.application.infrastructure.member.entity.MemberEntity;
+import way.application.utils.exception.BadRequestException;
+import way.application.utils.exception.ErrorResult;
+
+@Component
+@RequiredArgsConstructor
+public class MemberRepositoryImpl implements MemberRepository {
+	private final MemberJpaRepository memberJpaRepository;
+
+	@Override
+	public MemberEntity validateMemberSeq(Long memberSeq) {
+		return memberJpaRepository.findById(memberSeq)
+			.orElseThrow(() -> new BadRequestException(ErrorResult.MEMBER_SEQ_BAD_REQUEST_EXCEPTION));
+	}
+
+	@Override
+	public List<MemberEntity> validateMemberSeqs(List<Long> memberSeqs) {
+		if (memberSeqs == null || memberSeqs.isEmpty()) {
+			return Collections.emptyList();
+		}
+
+		List<MemberEntity> memberEntities = memberJpaRepository.findAllById(memberSeqs);
+		if (memberEntities.size() != memberSeqs.size()) {
+			throw new BadRequestException(ErrorResult.MEMBER_SEQ_BAD_REQUEST_EXCEPTION);
+		}
+
+		return memberEntities;
+	}
+}

--- a/infrastructure/src/main/java/way/application/infrastructure/schedule/repository/ScheduleRepository.java
+++ b/infrastructure/src/main/java/way/application/infrastructure/schedule/repository/ScheduleRepository.java
@@ -1,4 +1,7 @@
 package way.application.infrastructure.schedule.repository;
 
+import way.application.infrastructure.schedule.entity.ScheduleEntity;
+
 public interface ScheduleRepository {
+	ScheduleEntity saveSchedule(ScheduleEntity scheduleEntity);
 }

--- a/infrastructure/src/main/java/way/application/infrastructure/schedule/repository/ScheduleRepositoryImpl.java
+++ b/infrastructure/src/main/java/way/application/infrastructure/schedule/repository/ScheduleRepositoryImpl.java
@@ -1,0 +1,17 @@
+package way.application.infrastructure.schedule.repository;
+
+import org.springframework.stereotype.Component;
+
+import lombok.RequiredArgsConstructor;
+import way.application.infrastructure.schedule.entity.ScheduleEntity;
+
+@Component
+@RequiredArgsConstructor
+public class ScheduleRepositoryImpl implements ScheduleRepository {
+	private final ScheduleJpaRepository scheduleJpaRepository;
+
+	@Override
+	public ScheduleEntity saveSchedule(ScheduleEntity scheduleEntity) {
+		return scheduleJpaRepository.save(scheduleEntity);
+	}
+}

--- a/infrastructure/src/main/java/way/application/infrastructure/scheduleMember/repository/ScheduleMemberRepository.java
+++ b/infrastructure/src/main/java/way/application/infrastructure/scheduleMember/repository/ScheduleMemberRepository.java
@@ -1,0 +1,7 @@
+package way.application.infrastructure.scheduleMember.repository;
+
+import way.application.infrastructure.scheduleMember.entity.ScheduleMemberEntity;
+
+public interface ScheduleMemberRepository {
+	ScheduleMemberEntity saveScheduleMemberEntity(ScheduleMemberEntity scheduleMemberEntity);
+}

--- a/infrastructure/src/main/java/way/application/infrastructure/scheduleMember/repository/ScheduleMemberRepositoryImpl.java
+++ b/infrastructure/src/main/java/way/application/infrastructure/scheduleMember/repository/ScheduleMemberRepositoryImpl.java
@@ -1,0 +1,17 @@
+package way.application.infrastructure.scheduleMember.repository;
+
+import org.springframework.stereotype.Component;
+
+import lombok.RequiredArgsConstructor;
+import way.application.infrastructure.scheduleMember.entity.ScheduleMemberEntity;
+
+@Component
+@RequiredArgsConstructor
+public class ScheduleMemberRepositoryImpl implements ScheduleMemberRepository {
+	private final ScheduleMemberJpaRepository scheduleMemberJpaRepository;
+
+	@Override
+	public ScheduleMemberEntity saveScheduleMemberEntity(ScheduleMemberEntity scheduleMemberEntity) {
+		return scheduleMemberJpaRepository.save(scheduleMemberEntity);
+	}
+}

--- a/presentation/src/main/java/way/presentation/BackendApplication.java
+++ b/presentation/src/main/java/way/presentation/BackendApplication.java
@@ -2,12 +2,25 @@ package way.presentation;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.autoconfigure.domain.EntityScan;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
 
 @SpringBootApplication
+@EntityScan(basePackages = "way.application.infrastructure")
+@EnableJpaRepositories(basePackages = "way.application.infrastructure")
+@ComponentScan(basePackages = {
+	"way.application.utils",
+	"way.application.core",
+	"way.application.service",
+	"way.application.domain",
+	"way.application.infrastructure",
+	"way.presentation"
+})
 public class BackendApplication {
 
-    public static void main(String[] args) {
-        SpringApplication.run(BackendApplication.class, args);
-    }
+	public static void main(String[] args) {
+		SpringApplication.run(BackendApplication.class, args);
+	}
 
 }

--- a/presentation/src/main/java/way/presentation/schedule/controller/ScheduleController.java
+++ b/presentation/src/main/java/way/presentation/schedule/controller/ScheduleController.java
@@ -1,27 +1,34 @@
-// package way.presentation.schedule.controller;
-//
-// import org.springframework.http.ResponseEntity;
-// import org.springframework.web.bind.annotation.PostMapping;
-// import org.springframework.web.bind.annotation.RequestBody;
-// import org.springframework.web.bind.annotation.RequestMapping;
-// import org.springframework.web.bind.annotation.RestController;
-//
-// import jakarta.validation.Valid;
-// import lombok.RequiredArgsConstructor;
-// import way.presentation.base.BaseResponse;
-// import way.presentation.schedule.vo.req.SaveScheduleRequest;
-// import way.presentation.schedule.vo.res.SaveScheduleResponse;
-//
-// @RestController
-// @RequestMapping("/schedule")
-// @RequiredArgsConstructor
-// public class ScheduleController {
-//
-// 	@PostMapping()
-// 	public ResponseEntity<BaseResponse<SaveScheduleResponse>> saveSchedule(
-// 		@Valid
-// 		@RequestBody SaveScheduleRequest request
-// 	) {
-//
-// 	}
-// }
+package way.presentation.schedule.controller;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import way.application.service.schedule.service.ScheduleService;
+import way.presentation.base.BaseResponse;
+import way.presentation.schedule.vo.req.SaveScheduleRequest;
+import way.presentation.schedule.vo.res.SaveScheduleResponse;
+
+@RestController
+@RequestMapping("/schedule")
+@RequiredArgsConstructor
+public class ScheduleController {
+	private final ScheduleService scheduleService;
+
+	@PostMapping()
+	public ResponseEntity<BaseResponse<SaveScheduleResponse>> saveSchedule(
+		@Valid
+		@RequestBody SaveScheduleRequest request
+	) {
+		Long scheduleSeq = scheduleService.createSchedule(request.toScheduleDto());
+
+		return ResponseEntity.ok().body(
+			BaseResponse.ofSuccess(HttpStatus.OK.value(), new SaveScheduleResponse(scheduleSeq))
+		);
+	}
+}

--- a/service/src/main/java/way/application/service/schedule/mapper/ScheduleMapper.java
+++ b/service/src/main/java/way/application/service/schedule/mapper/ScheduleMapper.java
@@ -11,5 +11,5 @@ import way.application.service.schedule.dto.ScheduleDto;
 @Mapper(componentModel = "spring", injectionStrategy = InjectionStrategy.CONSTRUCTOR, unmappedTargetPolicy = ReportingPolicy.IGNORE)
 public interface ScheduleMapper {
 	@Mapping(target = "scheduleSeq", ignore = true)
-	ScheduleEntity toScheduleEntity(ScheduleDto dto);
+	ScheduleEntity toScheduleEntity(ScheduleDto scheduleDto);
 }

--- a/service/src/main/java/way/application/service/schedule/repository/ScheduleRepositoryImpl.java
+++ b/service/src/main/java/way/application/service/schedule/repository/ScheduleRepositoryImpl.java
@@ -1,7 +1,0 @@
-package way.application.service.schedule.repository;
-
-import way.application.infrastructure.schedule.repository.ScheduleRepository;
-
-public class ScheduleRepositoryImpl implements ScheduleRepository {
-
-}

--- a/service/src/main/java/way/application/service/schedule/service/ScheduleService.java
+++ b/service/src/main/java/way/application/service/schedule/service/ScheduleService.java
@@ -1,4 +1,67 @@
 package way.application.service.schedule.service;
 
+import java.util.List;
+import java.util.Set;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import lombok.RequiredArgsConstructor;
+import way.application.domain.firebase.FirebaseNotificationDomain;
+import way.application.domain.member.MemberDomain;
+import way.application.infrastructure.member.entity.MemberEntity;
+import way.application.infrastructure.member.repository.MemberRepository;
+import way.application.infrastructure.schedule.entity.ScheduleEntity;
+import way.application.infrastructure.schedule.repository.ScheduleRepository;
+import way.application.infrastructure.scheduleMember.repository.ScheduleMemberRepository;
+import way.application.service.schedule.dto.ScheduleDto;
+import way.application.service.schedule.mapper.ScheduleMapper;
+import way.application.service.scheduleMember.mapper.ScheduleMemberMapper;
+
+@Service
+@RequiredArgsConstructor
 public class ScheduleService {
+	private final ScheduleRepository scheduleRepository;
+	private final ScheduleMemberRepository scheduleMemberRepository;
+	private final MemberRepository memberRepository;
+
+	private final MemberDomain memberDomain;
+	private final FirebaseNotificationDomain firebaseNotificationDomain;
+
+	private final ScheduleMapper scheduleMapper;
+	private final ScheduleMemberMapper scheduleMemberMapper;
+
+	/**
+	 * @param scheduleDto
+	 *
+	 * 유효성 검사 -> Repository Interface 에서 처리
+	 * 비즈니스 로직 -> Domain 단에서 처리
+	 * Service 로직 -> Domain 호출 및 저장
+	 */
+	@Transactional
+	public Long createSchedule(ScheduleDto scheduleDto) {
+		// Member 유효성 검사 (Repository 에서 처리)
+		MemberEntity createMemberEntity = memberRepository.validateMemberSeq(scheduleDto.createMemberSeq());
+		List<MemberEntity> invitedMemberEntity = memberRepository.validateMemberSeqs(scheduleDto.invitedMemberSeqs());
+
+		// Schedule 저장
+		ScheduleEntity savedSchedule = scheduleRepository.saveSchedule(scheduleMapper.toScheduleEntity(scheduleDto));
+
+		// ScheduleMember 저장
+		Set<MemberEntity> invitedMembers = memberDomain.createMemberSet(createMemberEntity, invitedMemberEntity);
+		for (MemberEntity invitedMember : invitedMembers) {
+
+			// 일정 생성자 여부 확인 (Domain 처리)
+			boolean isCreator = memberDomain.checkIsCreator(invitedMember, createMemberEntity);
+			scheduleMemberRepository.saveScheduleMemberEntity(
+				scheduleMemberMapper.toScheduleMemberEntity(savedSchedule, invitedMember, isCreator, isCreator)
+			);
+
+			// 푸시 알림 여부 확인 (Domain 처리)
+			if (!isCreator)
+				firebaseNotificationDomain.sendNotification(invitedMember, createMemberEntity);
+		}
+
+		return savedSchedule.getScheduleSeq();
+	}
 }

--- a/service/src/main/java/way/application/service/scheduleMember/mapper/ScheduleMemberMapper.java
+++ b/service/src/main/java/way/application/service/scheduleMember/mapper/ScheduleMemberMapper.java
@@ -1,0 +1,18 @@
+package way.application.service.scheduleMember.mapper;
+
+import org.mapstruct.InjectionStrategy;
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+import org.mapstruct.ReportingPolicy;
+
+import way.application.infrastructure.member.entity.MemberEntity;
+import way.application.infrastructure.schedule.entity.ScheduleEntity;
+import way.application.infrastructure.scheduleMember.entity.ScheduleMemberEntity;
+
+@Mapper(componentModel = "spring", injectionStrategy = InjectionStrategy.CONSTRUCTOR, unmappedTargetPolicy = ReportingPolicy.IGNORE)
+public interface ScheduleMemberMapper {
+	@Mapping(target = "scheduleMemberSeq", ignore = true)
+	ScheduleMemberEntity toScheduleMemberEntity(
+		ScheduleEntity schedule, MemberEntity invitedMember, Boolean isCreator, Boolean acceptSchedule
+	);
+}

--- a/utils/src/main/java/way/application/utils/exception/GlobalExceptionHandler.java
+++ b/utils/src/main/java/way/application/utils/exception/GlobalExceptionHandler.java
@@ -14,6 +14,7 @@ import org.springframework.web.bind.annotation.RestControllerAdvice;
 import org.springframework.web.context.request.WebRequest;
 import org.springframework.web.servlet.mvc.method.annotation.ResponseEntityExceptionHandler;
 
+import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
@@ -58,6 +59,18 @@ public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
 
 		response.setStatus(HttpStatus.INTERNAL_SERVER_ERROR.value());
 		return this.makeErrorResponseEntity(ErrorResult.UNKNOWN_EXCEPTION);
+	}
+
+	@ExceptionHandler({BadRequestException.class})
+	public ResponseEntity<ErrorResponse> handleBadRequestException(
+		final BadRequestException exception,
+		HttpServletRequest request,
+		HttpServletResponse response
+	) {
+		log.warn("BadRequest Exception occur: ", exception);
+
+		response.setStatus(exception.getErrorResult().getHttpStatus().value());
+		return this.makeErrorResponseEntity(exception.getErrorResult());
 	}
 
 	private ResponseEntity<ErrorResponse> makeErrorResponseEntity(final ErrorResult errorResult) {


### PR DESCRIPTION
## 🌱 관련 이슈
- close #3

## 📌 작업 내용 및 특이사항
- ScheduleMemberRepositoryImpl 클래스 구현 및 saveScheduleMemberEntity 메서드 추가
   - ScheduleMemberJpaRepository를 사용하여 일정 회원 엔티티를 저장하는 메서드 구현
   - 주석 추가 및 코드 정리

- ScheduleService 클래스 구현 및 createSchedule 메서드 추가
   - ScheduleRepository, ScheduleMemberRepository, MemberRepository 주입
   - MemberDomain, FirebaseNotificationDomain 주입
   - ScheduleMapper, ScheduleMemberMapper 주입
   - createSchedule 메서드에서 일정 생성과 관련된 모든 로직 처리
   - 회원 유효성 검사, 일정 저장, 초대된 회원 정보 저장, 알림 발송 로직 포함

## 📝 참고사항
- 각 클래스와 메서드는 SRP(단일 책임 원칙)을 준수하여 구현되었습니다.
- 코드의 가독성과 유지 보수성을 높이기 위해 주석을 추가하고 메서드를 분리했습니다.

## 📚 기타
-일정 생성 및 알림 기능에 대한 추가적인 테스트가 필요할 수 있습니다.