### PR TITLE
Feature/#45

### DIFF
--- a/domain/src/main/java/way/application/domain/feed/FeedDomain.java
+++ b/domain/src/main/java/way/application/domain/feed/FeedDomain.java
@@ -2,7 +2,12 @@ package way.application.domain.feed;
 
 import org.springframework.stereotype.Component;
 
+import way.application.infrastructure.feed.entity.FeedEntity;
+
 @Component
 public class FeedDomain {
-
+	// Toggle hide
+	public FeedEntity toggleHide(FeedEntity feed) {
+		return feed.toBuilder().hide(!feed.getHide()).build();
+	}
 }

--- a/presentation/src/main/java/way/presentation/feed/controller/FeedController.java
+++ b/presentation/src/main/java/way/presentation/feed/controller/FeedController.java
@@ -12,6 +12,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -25,6 +26,7 @@ import lombok.RequiredArgsConstructor;
 import way.application.service.feed.service.FeedService;
 import way.application.utils.exception.GlobalExceptionHandler;
 import way.presentation.base.BaseResponse;
+import way.presentation.feed.validates.HideFeedValidator;
 import way.presentation.feed.validates.ModifyFeedValidator;
 import way.presentation.feed.validates.SaveFeedValidator;
 
@@ -34,6 +36,7 @@ import way.presentation.feed.validates.SaveFeedValidator;
 public class FeedController {
 	private final SaveFeedValidator saveFeedValidator;
 	private final ModifyFeedValidator modifyFeedValidator;
+	private final HideFeedValidator hideFeedValidator;
 
 	private final FeedService feedService;
 
@@ -41,7 +44,7 @@ public class FeedController {
 	@Operation(summary = "피드 생성 API", description = "피드 생성 API")
 	@ApiResponses(value = {
 		@ApiResponse(
-			responseCode = "201",
+			responseCode = "200",
 			description = "요청에 성공하였습니다.",
 			useReturnTypeSchema = true),
 		@ApiResponse(
@@ -88,7 +91,7 @@ public class FeedController {
 		// DTO -> VO
 		SaveFeedResponse response = new SaveFeedResponse(saveFeedResponseDto.feedSeq());
 
-		return ResponseEntity.ok().body(BaseResponse.ofSuccess(HttpStatus.CREATED.value(), response));
+		return ResponseEntity.ok().body(BaseResponse.ofSuccess(HttpStatus.OK.value(), response));
 	}
 
 	@PutMapping(name = "피드 수정")
@@ -127,12 +130,6 @@ public class FeedController {
 			description = "400 FEED_DIDNT_CREATED_BY_MEMBER_BAD_REQUEST_EXCEPTION / Member가 생성한 Feed가 아닌 경우",
 			content = @Content(
 				schema = @Schema(
-					implementation = GlobalExceptionHandler.ErrorResponse.class))),
-		@ApiResponse(
-			responseCode = "MSB002",
-			description = "400 MEMBER_SEQ_BAD_REQUEST_EXCEPTION / MEMBER_SEQ 오류",
-			content = @Content(
-				schema = @Schema(
 					implementation = GlobalExceptionHandler.ErrorResponse.class)))
 	})
 	public ResponseEntity<BaseResponse<ModifyFeedResponse>> modifyFeed(
@@ -149,5 +146,56 @@ public class FeedController {
 		ModifyFeedResponse response = new ModifyFeedResponse(modifyFeedResponseDto.feedSeq());
 
 		return ResponseEntity.ok().body(BaseResponse.ofSuccess(HttpStatus.OK.value(), response));
+	}
+
+	@PostMapping(name = "피드  숨김", value = "/hide")
+	@Operation(summary = "피드 숨김 API", description = "피드 숨김 API (숨김 -> 해제, 해제 -> 숨김 동시에 처리할 수 있습니다.)")
+	@ApiResponses(value = {
+		@ApiResponse(
+			responseCode = "200",
+			description = "요청에 성공하였습니다.",
+			useReturnTypeSchema = true),
+		@ApiResponse(
+			responseCode = "S500",
+			description = "500 SERVER_ERROR (나도 몰라 ..)",
+			content = @Content(
+				schema = @Schema(
+					implementation = GlobalExceptionHandler.ErrorResponse.class))),
+		@ApiResponse(
+			responseCode = "B001",
+			description = "400 Invalid DTO Parameter errors / 요청 값 형식 요류",
+			content = @Content(
+				schema = @Schema(
+					implementation = GlobalExceptionHandler.ErrorResponse.class))),
+		@ApiResponse(
+			responseCode = "MSB002",
+			description = "400 MEMBER_SEQ_BAD_REQUEST_EXCEPTION / MEMBER_SEQ 오류",
+			content = @Content(
+				schema = @Schema(
+					implementation = GlobalExceptionHandler.ErrorResponse.class))),
+		@ApiResponse(
+			responseCode = "FSB019",
+			description = "400 FEED_SEQ_BAD_REQUEST_EXCEPTION / FEED_SEQ 오류",
+			content = @Content(
+				schema = @Schema(
+					implementation = GlobalExceptionHandler.ErrorResponse.class))),
+		@ApiResponse(
+			responseCode = "FDCBMB020",
+			description = "400 FEED_DIDNT_CREATED_BY_MEMBER_BAD_REQUEST_EXCEPTION / Member가 생성한 Feed가 아닌 경우",
+			content = @Content(
+				schema = @Schema(
+					implementation = GlobalExceptionHandler.ErrorResponse.class)))
+	})
+	public ResponseEntity<BaseResponse> hideFeed(
+		@Valid
+		@RequestBody HideFeedRequest request
+	) throws IOException {
+		// 유효성 검사
+		hideFeedValidator.validate(request);
+
+		// VO -> DTO
+		feedService.hideFeed(request.toHideFeedRequestDto());
+
+		return ResponseEntity.ok().body(BaseResponse.ofSuccess(HttpStatus.OK.value(), "SUCCESS"));
 	}
 }

--- a/presentation/src/main/java/way/presentation/feed/validates/HideFeedValidator.java
+++ b/presentation/src/main/java/way/presentation/feed/validates/HideFeedValidator.java
@@ -1,0 +1,32 @@
+package way.presentation.feed.validates;
+
+import static way.presentation.feed.vo.req.FeedRequestVo.*;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Component;
+
+import way.application.utils.exception.BadRequestException;
+import way.application.utils.exception.ErrorResult;
+
+@Component
+public class HideFeedValidator {
+	private static final Logger logger = LoggerFactory.getLogger(HideFeedValidator.class);
+
+	public void validate(HideFeedRequest request) {
+		validateFeedSeq(request.feedSeq());
+		validateMemberSeq(request.creatorSeq());
+	}
+
+	private void validateFeedSeq(Long feedSeq) {
+		if (feedSeq == null) {
+			throw new BadRequestException(ErrorResult.DTO_BAD_REQUEST_EXCEPTION);
+		}
+	}
+
+	private void validateMemberSeq(Long memberSeq) {
+		if (memberSeq == null) {
+			throw new BadRequestException(ErrorResult.DTO_BAD_REQUEST_EXCEPTION);
+		}
+	}
+}

--- a/presentation/src/main/java/way/presentation/feed/vo/req/FeedRequestVo.java
+++ b/presentation/src/main/java/way/presentation/feed/vo/req/FeedRequestVo.java
@@ -42,4 +42,16 @@ public class FeedRequestVo {
 			);
 		}
 	}
+
+	public record HideFeedRequest(
+		Long feedSeq,
+		Long creatorSeq
+	) {
+		public HideFeedRequestDto toHideFeedRequestDto() {
+			return new HideFeedRequestDto(
+				this.feedSeq,
+				this.creatorSeq
+			);
+		}
+	}
 }

--- a/service/src/main/java/way/application/service/feed/dto/request/FeedRequestDto.java
+++ b/service/src/main/java/way/application/service/feed/dto/request/FeedRequestDto.java
@@ -33,4 +33,11 @@ public class FeedRequestDto {
 			);
 		}
 	}
+
+	public record HideFeedRequestDto(
+		Long feedSeq,
+		Long creatorSeq
+	) {
+
+	}
 }


### PR DESCRIPTION
## 🌱 관련 이슈
- close #45

## 📌 작업 내용 및 특이사항
- HideFeedRequest 및 HideFeedRequestDto 레코드 클래스 추가 (feedSeq, creatorSeq 필드 포함)
- FeedEntity의 숨김 상태를 반전시키는 toggleHide 메서드를 FeedDomain 클래스에 추가
- 피드 숨김/해제 기능을 위한 트랜잭션 처리 및 도메인 로직 구현
- hideFeed 메서드에서 creatorSeq로 MemberEntity 조회 후 feedSeq로 FeedEntity 조회
- FeedDomain의 toggleHide 메서드를 사용하여 FeedEntity의 숨김 상태 반전 후 저장
- HideFeedValidator에서 feedSeq와 creatorSeq에 대한 null 체크 검증 추가
- 피드 숨김 API의 요청 유효성 검사 및 예외 처리 추가
- Swagger 어노테이션을 사용하여 API 문서화 (요약, 설명, 응답 코드 등)

## 📝 참고사항
- 유효성 검사 실패 시 적절한 예외 처리 및 응답 코드 반환을 위해 `GlobalExceptionHandler` 사용
- @Valid 및 @RequestBody 어노테이션을 통해 요청 본문 유효성 검사 적용

## 📚 기타
- 없음