### PR TITLE
Feature/#59

### DIFF
--- a/infrastructure/src/main/java/way/application/infrastructure/hideFeed/repository/HideFeedRepository.java
+++ b/infrastructure/src/main/java/way/application/infrastructure/hideFeed/repository/HideFeedRepository.java
@@ -6,5 +6,7 @@ import way.application.infrastructure.member.entity.MemberEntity;
 
 public interface HideFeedRepository {
 	HideFeedEntity saveHideFeedEntity(HideFeedEntity hideFeedEntity);
-	void findHideFeedEntityByFeedEntityAndMemberEntity(FeedEntity feedEntity, MemberEntity memberEntity);
+	void deleteHideFeedEntity(HideFeedEntity hideFeedEntity);
+	void checkHideFeedEntityByFeedEntityAndMemberEntity(FeedEntity feedEntity, MemberEntity memberEntity);
+	HideFeedEntity findHideFeedEntityByFeedEntityAndMemberEntity(FeedEntity feedEntity, MemberEntity memberEntity);
 }

--- a/infrastructure/src/main/java/way/application/infrastructure/hideFeed/repository/HideFeedRepositoryImpl.java
+++ b/infrastructure/src/main/java/way/application/infrastructure/hideFeed/repository/HideFeedRepositoryImpl.java
@@ -8,6 +8,7 @@ import way.application.infrastructure.hideFeed.entity.HideFeedEntity;
 import way.application.infrastructure.member.entity.MemberEntity;
 import way.application.utils.exception.ConflictException;
 import way.application.utils.exception.ErrorResult;
+import way.application.utils.exception.NotFoundRequestException;
 
 @Component
 @RequiredArgsConstructor
@@ -20,10 +21,24 @@ public class HideFeedRepositoryImpl implements HideFeedRepository {
 	}
 
 	@Override
-	public void findHideFeedEntityByFeedEntityAndMemberEntity(FeedEntity feedEntity, MemberEntity memberEntity) {
+	public void deleteHideFeedEntity(HideFeedEntity hideFeedEntity) {
+		hideFeedJpaRepository.delete(hideFeedEntity);
+	}
+
+	@Override
+	public void checkHideFeedEntityByFeedEntityAndMemberEntity(FeedEntity feedEntity, MemberEntity memberEntity) {
 		hideFeedJpaRepository.findHideFeedEntityByFeedEntityAndMemberEntity(feedEntity, memberEntity)
 			.ifPresent(entity -> {
 				throw new ConflictException(ErrorResult.HIDE_FEED_DUPLICATION_CONFLICT_EXCEPTION);
 			});
+	}
+
+	@Override
+	public HideFeedEntity findHideFeedEntityByFeedEntityAndMemberEntity(
+		FeedEntity feedEntity,
+		MemberEntity memberEntity
+	) {
+		return hideFeedJpaRepository.findHideFeedEntityByFeedEntityAndMemberEntity(feedEntity, memberEntity)
+			.orElseThrow(() -> new NotFoundRequestException(ErrorResult.HIDE_FEED_NOT_FOUND_EXCEPTION));
 	}
 }

--- a/presentation/src/main/java/way/presentation/hideFeed/controller/HideFeedController.java
+++ b/presentation/src/main/java/way/presentation/hideFeed/controller/HideFeedController.java
@@ -6,6 +6,7 @@ import static way.presentation.hideFeed.vo.res.HideFeedResponseVo.*;
 
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -23,6 +24,7 @@ import way.application.service.hideFeed.service.HideFeedService;
 import way.application.utils.exception.GlobalExceptionHandler;
 import way.presentation.base.BaseResponse;
 import way.presentation.hideFeed.validates.AddHideFeedValidator;
+import way.presentation.hideFeed.validates.DeleteHideFeedValidator;
 
 @RestController
 @RequestMapping("/hide-feed")
@@ -30,6 +32,7 @@ import way.presentation.hideFeed.validates.AddHideFeedValidator;
 @Tag(name = "피드 숨김", description = "담당자 (박종훈)")
 public class HideFeedController {
 	private final AddHideFeedValidator addHideFeedValidator;
+	private final DeleteHideFeedValidator deleteHideFeedValidator;
 
 	private final HideFeedService hideFeedService;
 
@@ -91,5 +94,56 @@ public class HideFeedController {
 		AddHideFeedResponse response = new AddHideFeedResponse(addHideFeedResponseDto.hideFeedSeq());
 
 		return ResponseEntity.ok().body(BaseResponse.ofSuccess(HttpStatus.OK.value(), response));
+	}
+
+	@DeleteMapping(name = "피드  숨김 복원")
+	@Operation(summary = "피드  숨김 복원 API", description = "피드  숨김 복원 API")
+	@ApiResponses(value = {
+		@ApiResponse(
+			responseCode = "200",
+			description = "요청에 성공하였습니다.",
+			useReturnTypeSchema = true),
+		@ApiResponse(
+			responseCode = "S500",
+			description = "500 SERVER_ERROR (나도 몰라 ..)",
+			content = @Content(
+				schema = @Schema(
+					implementation = GlobalExceptionHandler.ErrorResponse.class))),
+		@ApiResponse(
+			responseCode = "B001",
+			description = "400 Invalid DTO Parameter errors / 요청 값 형식 요류",
+			content = @Content(
+				schema = @Schema(
+					implementation = GlobalExceptionHandler.ErrorResponse.class))),
+		@ApiResponse(
+			responseCode = "MSB002",
+			description = "400 MEMBER_SEQ_BAD_REQUEST_EXCEPTION / MEMBER_SEQ 오류",
+			content = @Content(
+				schema = @Schema(
+					implementation = GlobalExceptionHandler.ErrorResponse.class))),
+		@ApiResponse(
+			responseCode = "FSB019",
+			description = "400 FEED_SEQ_BAD_REQUEST_EXCEPTION / FEED_SEQ 오류",
+			content = @Content(
+				schema = @Schema(
+					implementation = GlobalExceptionHandler.ErrorResponse.class))),
+		@ApiResponse(
+			responseCode = "HFEN001",
+			description = "400 HIDE_FEED_NOT_FOUND_EXCEPTION / Member가 숨김한 Hide Feed가 없을 때 오류",
+			content = @Content(
+				schema = @Schema(
+					implementation = GlobalExceptionHandler.ErrorResponse.class)))
+	})
+	public ResponseEntity<BaseResponse> deleteHideFeed(
+		@Valid
+		@RequestBody DeleteHideFeedRequest request
+	) {
+		// 유효성 검사
+		deleteHideFeedValidator.validate(request);
+
+		// VO -> DTO
+		hideFeedService.deleteHideFeed(request.toDeleteHideFeedRequestDto());
+
+		return ResponseEntity.ok().body(BaseResponse.ofSuccess(HttpStatus.OK.value(), "SUCCESS"));
 	}
 }

--- a/presentation/src/main/java/way/presentation/hideFeed/validates/DeleteHideFeedValidator.java
+++ b/presentation/src/main/java/way/presentation/hideFeed/validates/DeleteHideFeedValidator.java
@@ -1,0 +1,28 @@
+package way.presentation.hideFeed.validates;
+
+import static way.presentation.hideFeed.vo.req.HideFeedRequestVo.*;
+
+import org.springframework.stereotype.Component;
+
+import way.application.utils.exception.BadRequestException;
+import way.application.utils.exception.ErrorResult;
+
+@Component
+public class DeleteHideFeedValidator {
+	public void validate(DeleteHideFeedRequest request) {
+		validateHideFeedSeq(request.hideFeedSeq());
+		validateMemberSeq(request.memberSeq());
+	}
+
+	private void validateHideFeedSeq(Long hideFeedSeq) {
+		if (hideFeedSeq == null) {
+			throw new BadRequestException(ErrorResult.DTO_BAD_REQUEST_EXCEPTION);
+		}
+	}
+
+	private void validateMemberSeq(Long memberSeq) {
+		if (memberSeq == null) {
+			throw new BadRequestException(ErrorResult.DTO_BAD_REQUEST_EXCEPTION);
+		}
+	}
+}

--- a/presentation/src/main/java/way/presentation/hideFeed/vo/req/HideFeedRequestVo.java
+++ b/presentation/src/main/java/way/presentation/hideFeed/vo/req/HideFeedRequestVo.java
@@ -14,4 +14,16 @@ public class HideFeedRequestVo {
 			);
 		}
 	}
+
+	public record DeleteHideFeedRequest(
+		Long hideFeedSeq,
+		Long memberSeq
+	) {
+		public DeleteHideFeedRequestDto toDeleteHideFeedRequestDto() {
+			return new DeleteHideFeedRequestDto(
+				this.hideFeedSeq,
+				this.memberSeq
+			);
+		}
+	}
 }

--- a/service/src/main/java/way/application/service/hideFeed/dto/request/HideFeedRequestDto.java
+++ b/service/src/main/java/way/application/service/hideFeed/dto/request/HideFeedRequestDto.java
@@ -7,4 +7,11 @@ public class HideFeedRequestDto {
 	) {
 
 	}
+
+	public record DeleteHideFeedRequestDto(
+		Long hideFeedSeq,
+		Long memberSeq
+	) {
+
+	}
 }

--- a/service/src/main/java/way/application/service/hideFeed/service/HideFeedService.java
+++ b/service/src/main/java/way/application/service/hideFeed/service/HideFeedService.java
@@ -13,8 +13,6 @@ import way.application.infrastructure.hideFeed.entity.HideFeedEntity;
 import way.application.infrastructure.hideFeed.repository.HideFeedRepository;
 import way.application.infrastructure.member.entity.MemberEntity;
 import way.application.infrastructure.member.repository.MemberRepository;
-import way.application.infrastructure.schedule.repository.ScheduleRepository;
-import way.application.infrastructure.scheduleMember.repository.ScheduleMemberRepository;
 import way.application.service.hideFeed.mapper.HideFeedMapper;
 
 @Service
@@ -29,7 +27,6 @@ public class HideFeedService {
 	@Transactional
 	public AddHideFeedResponseDto addHideFeed(AddHideFeedRequestDto addHideFeedRequestDto) {
 		/*
-		 예외처리 (Repo 단)
 		 1. Member 확인
 		 2. Feed 확인
 		 3. Feed 작성자 확인
@@ -41,7 +38,7 @@ public class HideFeedService {
 			memberEntity,
 			addHideFeedRequestDto.hideFeedSeq()
 		);
-		hideFeedRepository.findHideFeedEntityByFeedEntityAndMemberEntity(
+		hideFeedRepository.checkHideFeedEntityByFeedEntityAndMemberEntity(
 			feedEntity,
 			memberEntity
 		);
@@ -52,5 +49,23 @@ public class HideFeedService {
 		);
 
 		return new AddHideFeedResponseDto(hideFeedEntity.getHideFeedSeq());
+	}
+
+	@Transactional
+	public void deleteHideFeed(DeleteHideFeedRequestDto hideFeedRequestDto) {
+		/*
+		 1. Member 확인
+		 2. Feed 확인
+		 3. Hide Feed 작성자 확인
+		*/
+		MemberEntity memberEntity = memberRepository.findByMemberSeq(hideFeedRequestDto.memberSeq());
+		FeedEntity feedEntity = feedRepository.findByFeedSeq(hideFeedRequestDto.hideFeedSeq());
+		HideFeedEntity hideFeedEntity = hideFeedRepository.findHideFeedEntityByFeedEntityAndMemberEntity(
+			feedEntity,
+			memberEntity
+		);
+
+		// Hide Feed 삭제
+		hideFeedRepository.deleteHideFeedEntity(hideFeedEntity);
 	}
 }

--- a/utils/src/main/java/way/application/utils/exception/ErrorResult.java
+++ b/utils/src/main/java/way/application/utils/exception/ErrorResult.java
@@ -76,6 +76,13 @@ public enum ErrorResult {
 		"FDCBMB020"
 	),
 
+	// NOT FOUND
+	HIDE_FEED_NOT_FOUND_EXCEPTION(
+		HttpStatus.NOT_FOUND.value(),
+		"HIDE_FEED_NOT_FOUND_EXCEPTION",
+		"HFEN001"
+	),
+
 	// CONFLICT
 	USER_ID_DUPLICATION_CONFLICT_EXCEPTION(
 		HttpStatus.CONFLICT.value(),

--- a/utils/src/main/java/way/application/utils/exception/GlobalExceptionHandler.java
+++ b/utils/src/main/java/way/application/utils/exception/GlobalExceptionHandler.java
@@ -1,20 +1,11 @@
 package way.application.utils.exception;
 
-import java.util.List;
-import java.util.stream.Collectors;
-
-import org.springframework.context.support.DefaultMessageSourceResolvable;
-import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
-import org.springframework.http.HttpStatusCode;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
-import org.springframework.web.context.request.WebRequest;
 import org.springframework.web.servlet.mvc.method.annotation.ResponseEntityExceptionHandler;
 
-import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
@@ -24,7 +15,6 @@ import lombok.extern.slf4j.Slf4j;
 @RestControllerAdvice
 @RequiredArgsConstructor
 public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
-
 
 	@ExceptionHandler({Exception.class})
 	public ResponseEntity<ErrorResponse> handleException(
@@ -43,6 +33,17 @@ public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
 		HttpServletResponse response
 	) {
 		log.warn("BadRequest Exception occur: ", exception);
+
+		response.setStatus(exception.getErrorResult().getHttpStatus());
+		return this.makeErrorResponseEntity(exception.getErrorResult());
+	}
+
+	@ExceptionHandler({NotFoundRequestException.class})
+	public ResponseEntity<ErrorResponse> handleNotFoundException(
+		final NotFoundRequestException exception,
+		HttpServletResponse response
+	) {
+		log.warn("Not Found Exception occur: ", exception);
 
 		response.setStatus(exception.getErrorResult().getHttpStatus());
 		return this.makeErrorResponseEntity(exception.getErrorResult());

--- a/utils/src/main/java/way/application/utils/exception/NotFoundRequestException.java
+++ b/utils/src/main/java/way/application/utils/exception/NotFoundRequestException.java
@@ -1,0 +1,10 @@
+package way.application.utils.exception;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public class NotFoundRequestException extends RuntimeException {
+	private final ErrorResult errorResult;
+}


### PR DESCRIPTION
## 🌱 관련 이슈
- close #55

## 📌 작업 내용 및 특이사항
- 피드 숨김 복원 API 구현
  - `@DeleteMapping` 어노테이션을 사용하여 피드 숨김 복원 엔드포인트 설정
  - 다양한 응답 코드에 대한 설명 추가 (`@ApiResponses` 사용)
  - 요청 데이터 유효성 검사 및 서비스 레이어 호출
  - 성공 응답 반환
- `HIDE_FEED_NOT_FOUND_EXCEPTION` 예외 처리 로직 추가
  - 예외 발생 시 로그 경고 출력 및 응답 상태 코드 설정
- 피드 숨김 엔티티 관련 기능 구현
  - 숨김된 피드 엔티티 삭제, 중복 확인, 엔티티 검색 및 예외 처리
- `DeleteHideFeedRequest` 및 `DeleteHideFeedRequestDto` 레코드 클래스 추가
  - 요청 데이터와 DTO 변환 메소드 구현
- `NotFoundRequestException` 클래스 추가
  - `RuntimeException`을 상속받아 구현, `errorResult` 필드 추가
- `DeleteHideFeedValidator` 클래스 추가
  - 요청 데이터 유효성 검사 로직 구현 (`hideFeedSeq`와 `memberSeq` 검사)
- 피드 숨김 복원 서비스 로직 추가
  - 트랜잭션 관리 설정
  - 회원 확인, 피드 확인, 숨김된 피드 엔티티 확인 및 삭제

## 📝 참고사항
- 

## 📚 기타
-
