### PR TITLE
Feature/#65

### DIFF
--- a/infrastructure/src/main/java/way/application/infrastructure/feedImage/entity/FeedImageEntity.java
+++ b/infrastructure/src/main/java/way/application/infrastructure/feedImage/entity/FeedImageEntity.java
@@ -34,7 +34,7 @@ public class FeedImageEntity {
 
 	@ManyToOne(fetch = FetchType.LAZY)
 	@JoinColumn(name = "feed_seq")
-	private FeedEntity feed;
+	private FeedEntity feedEntity;
 
 	private String feedImageURL;
 }

--- a/infrastructure/src/main/java/way/application/infrastructure/feedImage/repository/FeedImageJpaRepository.java
+++ b/infrastructure/src/main/java/way/application/infrastructure/feedImage/repository/FeedImageJpaRepository.java
@@ -1,7 +1,8 @@
 package way.application.infrastructure.feedImage.repository;
 
+import java.util.List;
+
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 
 import way.application.infrastructure.feed.entity.FeedEntity;
@@ -9,5 +10,6 @@ import way.application.infrastructure.feedImage.entity.FeedImageEntity;
 
 @Repository
 public interface FeedImageJpaRepository extends JpaRepository<FeedImageEntity, Long> {
-	void deleteAllByFeed(FeedEntity feedEntity);
+	void deleteAllByFeedEntity(FeedEntity feedEntity);
+	List<FeedImageEntity> findAllByFeedEntity(FeedEntity feedEntity);
 }

--- a/infrastructure/src/main/java/way/application/infrastructure/feedImage/repository/FeedImageRepository.java
+++ b/infrastructure/src/main/java/way/application/infrastructure/feedImage/repository/FeedImageRepository.java
@@ -1,10 +1,12 @@
 package way.application.infrastructure.feedImage.repository;
 
+import java.util.List;
+
 import way.application.infrastructure.feed.entity.FeedEntity;
 import way.application.infrastructure.feedImage.entity.FeedImageEntity;
 
 public interface FeedImageRepository {
 	FeedImageEntity saveFeedImageEntity(FeedImageEntity feedImageEntity);
-
 	void deleteAllByFeedEntity(FeedEntity feedEntity);
+	List<FeedImageEntity> findAllByFeedEntity(FeedEntity feedEntity);
 }

--- a/infrastructure/src/main/java/way/application/infrastructure/feedImage/repository/FeedImageRepositoryImpl.java
+++ b/infrastructure/src/main/java/way/application/infrastructure/feedImage/repository/FeedImageRepositoryImpl.java
@@ -1,5 +1,7 @@
 package way.application.infrastructure.feedImage.repository;
 
+import java.util.List;
+
 import org.springframework.stereotype.Component;
 
 import lombok.RequiredArgsConstructor;
@@ -18,6 +20,11 @@ public class FeedImageRepositoryImpl implements FeedImageRepository {
 
 	@Override
 	public void deleteAllByFeedEntity(FeedEntity feedEntity) {
-		feedImageJpaRepository.deleteAllByFeed(feedEntity);
+		feedImageJpaRepository.deleteAllByFeedEntity(feedEntity);
+	}
+
+	@Override
+	public List<FeedImageEntity> findAllByFeedEntity(FeedEntity feedEntity) {
+		return feedImageJpaRepository.findAllByFeedEntity(feedEntity);
 	}
 }

--- a/infrastructure/src/main/java/way/application/infrastructure/hideFeed/repository/HideFeedJpaRepository.java
+++ b/infrastructure/src/main/java/way/application/infrastructure/hideFeed/repository/HideFeedJpaRepository.java
@@ -2,6 +2,8 @@ package way.application.infrastructure.hideFeed.repository;
 
 import java.util.Optional;
 
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
@@ -15,4 +17,6 @@ public interface HideFeedJpaRepository extends JpaRepository<HideFeedEntity, Lon
 		FeedEntity feedEntity,
 		MemberEntity memberEntity
 	);
+
+	Page<HideFeedEntity> findAllByMemberEntity(MemberEntity memberEntity, Pageable pageable);
 }

--- a/infrastructure/src/main/java/way/application/infrastructure/hideFeed/repository/HideFeedRepository.java
+++ b/infrastructure/src/main/java/way/application/infrastructure/hideFeed/repository/HideFeedRepository.java
@@ -1,5 +1,8 @@
 package way.application.infrastructure.hideFeed.repository;
 
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
 import way.application.infrastructure.feed.entity.FeedEntity;
 import way.application.infrastructure.hideFeed.entity.HideFeedEntity;
 import way.application.infrastructure.member.entity.MemberEntity;
@@ -9,4 +12,5 @@ public interface HideFeedRepository {
 	void deleteHideFeedEntity(HideFeedEntity hideFeedEntity);
 	void checkHideFeedEntityByFeedEntityAndMemberEntity(FeedEntity feedEntity, MemberEntity memberEntity);
 	HideFeedEntity findHideFeedEntityByFeedEntityAndMemberEntity(FeedEntity feedEntity, MemberEntity memberEntity);
+	Page<HideFeedEntity> findAllByMemberEntity(MemberEntity memberEntity, Pageable pageable);
 }

--- a/infrastructure/src/main/java/way/application/infrastructure/hideFeed/repository/HideFeedRepositoryImpl.java
+++ b/infrastructure/src/main/java/way/application/infrastructure/hideFeed/repository/HideFeedRepositoryImpl.java
@@ -1,5 +1,7 @@
 package way.application.infrastructure.hideFeed.repository;
 
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Component;
 
 import lombok.RequiredArgsConstructor;
@@ -40,5 +42,10 @@ public class HideFeedRepositoryImpl implements HideFeedRepository {
 	) {
 		return hideFeedJpaRepository.findHideFeedEntityByFeedEntityAndMemberEntity(feedEntity, memberEntity)
 			.orElseThrow(() -> new NotFoundRequestException(ErrorResult.HIDE_FEED_NOT_FOUND_EXCEPTION));
+	}
+
+	@Override
+	public Page<HideFeedEntity> findAllByMemberEntity(MemberEntity memberEntity, Pageable pageable) {
+		return hideFeedJpaRepository.findAllByMemberEntity(memberEntity, pageable);
 	}
 }

--- a/presentation/src/main/java/way/presentation/hideFeed/validates/GetHideFeedValidator.java
+++ b/presentation/src/main/java/way/presentation/hideFeed/validates/GetHideFeedValidator.java
@@ -1,0 +1,19 @@
+package way.presentation.hideFeed.validates;
+
+import org.springframework.stereotype.Component;
+
+import way.application.utils.exception.BadRequestException;
+import way.application.utils.exception.ErrorResult;
+
+@Component
+public class GetHideFeedValidator {
+	public void validate(Long memberSeq) {
+		validateHideFeedSeq(memberSeq);
+	}
+
+	private void validateHideFeedSeq(Long memberSeq) {
+		if (memberSeq == null) {
+			throw new BadRequestException(ErrorResult.DTO_BAD_REQUEST_EXCEPTION);
+		}
+	}
+}

--- a/presentation/src/main/java/way/presentation/hideFeed/vo/res/HideFeedResponseVo.java
+++ b/presentation/src/main/java/way/presentation/hideFeed/vo/res/HideFeedResponseVo.java
@@ -1,8 +1,25 @@
 package way.presentation.hideFeed.vo.res;
 
+import java.time.LocalDateTime;
+import java.util.List;
+
 public class HideFeedResponseVo {
 	public record AddHideFeedResponse(
 		Long hideFeedSeq
+	) {
+
+	}
+
+	public record GetHideFeedResponse(
+		String profileImage,
+		LocalDateTime startTime,
+		String location,
+		String title,
+		List<String> feedImageUrl,
+		String content
+
+		// TODO: bookMark 기능 추가
+		// Boolean bookMark
 	) {
 
 	}

--- a/service/src/main/java/way/application/service/feedImage/mapper/FeedImageMapper.java
+++ b/service/src/main/java/way/application/service/feedImage/mapper/FeedImageMapper.java
@@ -11,7 +11,7 @@ import way.application.infrastructure.feedImage.entity.FeedImageEntity;
 @Mapper(componentModel = "spring", injectionStrategy = InjectionStrategy.CONSTRUCTOR, unmappedTargetPolicy = ReportingPolicy.IGNORE)
 public interface FeedImageMapper {
 	@Mapping(target = "feedImageSeq", ignore = true)
-	@Mapping(target = "feed", source = "feed")
+	@Mapping(target = "feedEntity", source = "feed")
 	@Mapping(target = "feedImageURL", source = "feedImageURL")
 	FeedImageEntity toFeedImageEntity(FeedEntity feed, String feedImageURL);
 }

--- a/service/src/main/java/way/application/service/hideFeed/dto/response/HideFeedResponseDto.java
+++ b/service/src/main/java/way/application/service/hideFeed/dto/response/HideFeedResponseDto.java
@@ -1,8 +1,25 @@
 package way.application.service.hideFeed.dto.response;
 
+import java.time.LocalDateTime;
+import java.util.List;
+
 public class HideFeedResponseDto {
 	public record AddHideFeedResponseDto(
 		Long hideFeedSeq
+	) {
+
+	}
+
+	public record GetHideFeedResponseDto(
+		String profileImage,
+		LocalDateTime startTime,
+		String location,
+		String title,
+		List<String> feedImageUrl,
+		String content
+
+		// TODO: bookMark 기능 추가
+		// Boolean bookMark
 	) {
 
 	}

--- a/service/src/main/java/way/application/service/hideFeed/service/HideFeedService.java
+++ b/service/src/main/java/way/application/service/hideFeed/service/HideFeedService.java
@@ -3,16 +3,24 @@ package way.application.service.hideFeed.service;
 import static way.application.service.hideFeed.dto.request.HideFeedRequestDto.*;
 import static way.application.service.hideFeed.dto.response.HideFeedResponseDto.*;
 
+import java.util.List;
+import java.util.stream.Collectors;
+
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import lombok.RequiredArgsConstructor;
 import way.application.infrastructure.feed.entity.FeedEntity;
 import way.application.infrastructure.feed.repository.FeedRepository;
+import way.application.infrastructure.feedImage.entity.FeedImageEntity;
+import way.application.infrastructure.feedImage.repository.FeedImageRepository;
 import way.application.infrastructure.hideFeed.entity.HideFeedEntity;
 import way.application.infrastructure.hideFeed.repository.HideFeedRepository;
 import way.application.infrastructure.member.entity.MemberEntity;
 import way.application.infrastructure.member.repository.MemberRepository;
+import way.application.infrastructure.schedule.entity.ScheduleEntity;
 import way.application.service.hideFeed.mapper.HideFeedMapper;
 
 @Service
@@ -21,6 +29,7 @@ public class HideFeedService {
 	private final HideFeedRepository hideFeedRepository;
 	private final MemberRepository memberRepository;
 	private final FeedRepository feedRepository;
+	private final FeedImageRepository feedImageRepository;
 
 	private final HideFeedMapper hideFeedMapper;
 
@@ -67,5 +76,39 @@ public class HideFeedService {
 
 		// Hide Feed 삭제
 		hideFeedRepository.deleteHideFeedEntity(hideFeedEntity);
+	}
+
+	@Transactional(readOnly = true)
+	public Page<GetHideFeedResponseDto> getHideFeed(Long memberSeq, Pageable pageable) {
+		/*
+		 1. Member 확인
+		*/
+		MemberEntity memberEntity = memberRepository.findByMemberSeq(memberSeq);
+		// 2. HideFeedEntity 가져오기
+		Page<HideFeedEntity> hideFeedEntityPage = hideFeedRepository.findAllByMemberEntity(memberEntity, pageable);
+
+		// 3. HideFeedEntity를 GetHideFeedResponseDto로 변환
+		return hideFeedEntityPage.map(hideFeedEntity -> {
+			FeedEntity feedEntity = hideFeedEntity.getFeedEntity();
+			ScheduleEntity scheduleEntity = feedEntity.getSchedule();
+
+			// Feed 이미지 가져오기
+			List<String> feedImageUrl = feedImageRepository.findAllByFeedEntity(feedEntity)
+				.stream()
+				.map(FeedImageEntity::getFeedImageURL)
+				.collect(Collectors.toList());
+
+			// TODO: 북마크 상태 확인 (구현에 따라 수정 필요)
+			// Boolean bookMark = checkBookMarkStatus(feedEntity, hideFeedEntity.getMemberEntity());
+
+			return new GetHideFeedResponseDto(
+				hideFeedEntity.getMemberEntity().getProfileImage(),
+				scheduleEntity.getStartTime(),
+				scheduleEntity.getLocation(),
+				feedEntity.getTitle(),
+				feedImageUrl,
+				feedEntity.getContent()
+			);
+		});
 	}
 }


### PR DESCRIPTION
## 🌱 관련 이슈
- close #65

## 📌 작업 내용 및 특이사항
- 피드 숨김 조회 API 추가
  - @GetMapping 추가: /{memberSeq} 경로에 대한 피드 숨김 조회 엔드포인트 구현
  - @ApiResponses 및 @Parameters 추가: API 문서화 및 응답 코드 설명
    - 200: 요청 성공
    - 500: 서버 오류
    - 400: 요청 값 형식 오류 및 MEMBER_SEQ 오류
  - getHideFeed 메서드 추가: 회원의 숨긴 피드를 페이징 처리하여 조회
    - memberSeq, page, size 파라미터 유효성 검사
    - hideFeedService.getHideFeed 메서드를 호출하여 숨긴 피드 데이터 조회
    - 조회된 DTO를 VO로 변환하여 응답

- HideFeedService 클래스 추가 및 피드 숨기기 기능 구현
  - @Transactional(readOnly = true) 어노테이션 사용하여 읽기 전용 트랜잭션 설정
  - Member 확인: memberRepository.findByMemberSeq(memberSeq) 호출
  - 숨긴 피드 데이터 조회: hideFeedRepository.findAllByMemberEntity(memberEntity, pageable) 호출하여 페이징 처리된 HideFeedEntity 반환
  - HideFeedEntity를 GetHideFeedResponseDto로 변환
    - FeedEntity와 ScheduleEntity 가져오기
    - Feed 이미지 URL 리스트 가져오기: feedImageRepository.findAllByFeedEntity(feedEntity) 호출 후 URL 리스트로 변환
    - GetHideFeedResponseDto 객체 생성 및 반환
  - TODO: 북마크 상태 확인 로직 추가 예정

- GetHideFeedValidator 클래스 추가 및 유효성 검사 구현
  - GetHideFeedValidator 클래스 정의: 피드 숨김 조회 요청 객체의 유효성 검사
  - validate 메서드 추가: memberSeq 필드 유효성 검사 수행
  - validateHideFeedSeq 메서드 추가: memberSeq 필드가 null인지 검사
  - 필드가 null일 경우 BadRequestException 발생, ErrorResult.DTO_BAD_REQUEST_EXCEPTION 사용

## 📝 참고사항
- 

## 📚 기타
- 
