### PR TITLE
fix: CoordinateEntityMapper 매핑 오류 해결을 위한 명시적 매핑 추가 #189

### DIFF
--- a/service/src/main/java/way/application/service/coordinate/mapper/CoordinateEntityMapper.java
+++ b/service/src/main/java/way/application/service/coordinate/mapper/CoordinateEntityMapper.java
@@ -17,6 +17,8 @@ public interface CoordinateEntityMapper {
 	@Mapping(target = "coordinateSeq", ignore = true)
 	@Mapping(target = "memberEntity", source = "memberEntity")
 	@Mapping(target = "scheduleEntity", source = "scheduleEntity")
+	@Mapping(target = "x", source = "requestDto.x")
+	@Mapping(target = "y", source = "requestDto.y")
 	CoordinateEntity toCoordinateEntity(
 		MemberEntity memberEntity,
 		ScheduleEntity scheduleEntity,


### PR DESCRIPTION
- toCoordinateEntity 메서드에서 x와 y 속성을 requestDto의 필드와 명확하게 매핑
- 여러 소스 속성으로 인한 매핑 혼란 문제 수정

## 🌱 관련 이슈
- close #

## 📌 작업 내용 및 특이사항
- 

## 📝 참고사항
- 

## 📚 기타
-