### PR TITLE
fix: Schedule 시작 시간 검증 로직 제거 (#223)

### DIFF
--- a/service/src/main/java/way/application/service/schedule/service/ScheduleService.java
+++ b/service/src/main/java/way/application/service/schedule/service/ScheduleService.java
@@ -306,12 +306,10 @@ public class ScheduleService {
 		 1. Member 유효성 검사
 		 2. Schedule 유효성 검사
 		 3. Schdule Member 존재 유효성 검사
-		 4. Start Time 유효성 검사
 		*/
 		memberRepository.findByMemberSeq(memberSeq);
 		ScheduleEntity scheduleEntity = scheduleRepository.findByScheduleSeq(scheduleSeq);
 		scheduleMemberRepository.findAcceptedScheduleMemberInSchedule(scheduleSeq, memberSeq);
-		scheduleDomain.validateScheduleStartTime(scheduleEntity.getStartTime());
 
 		/*
 		 ScheduleEntity 에서 ScheduleMemberEntity 추출


### PR DESCRIPTION
- 기존 메서드에서 Schedule 시작 시간 유효성 검증 로직 제거
- `validateScheduleStartTime` 호출 삭제

## 🌱 관련 이슈
- close #

## 📌 작업 내용 및 특이사항
- 

## 📝 참고사항
- 

## 📚 기타
-