### PR TITLE
feat: ScheduleFriendInfo를 ScheduleFeedInfo의 memberSeq 순서에 맞게 정렬 기능 추가…

### DIFF
--- a/service/src/main/java/way/application/service/feed/service/FeedService.java
+++ b/service/src/main/java/way/application/service/feed/service/FeedService.java
@@ -272,7 +272,28 @@ public class FeedService {
 		// Schedule Info 생성
 		ScheduleInfo scheduleInfo = feedEntityMapper.toScheduleInfo(scheduleEntity);
 
-		return feedEntityMapper.toGetFeedResponseDto(scheduleInfo, scheduleFeedInfos, scheduleFriendInfo);
+		// ScheduleFriendInfo 정렬
+		List<Long> feedMemberSeqs = scheduleFeedInfos.stream()
+			.map(scheduleFeedInfo -> scheduleFeedInfo.memberInfo().memberSeq())
+			.toList();
+
+		List<ScheduleFriendInfo> sortedScheduleFriendInfo = scheduleFriendInfo.stream()
+			.sorted((friend1, friend2) -> {
+				int index1 = feedMemberSeqs.indexOf(friend1.memberSeq());
+				int index2 = feedMemberSeqs.indexOf(friend2.memberSeq());
+
+				if (index1 == -1) {
+					index1 = Integer.MAX_VALUE;
+				}
+				if (index2 == -1) {
+					index2 = Integer.MAX_VALUE;
+				}
+
+				return Integer.compare(index1, index2);
+			})
+			.toList();
+
+		return feedEntityMapper.toGetFeedResponseDto(scheduleInfo, scheduleFeedInfos, sortedScheduleFriendInfo);
 	}
 
 	@Transactional


### PR DESCRIPTION
… (#230)

- ScheduleFriendInfo를 ScheduleFeedInfo의 memberSeq 순서에 맞게 정렬하도록 로직 추가
- ScheduleFeedInfo의 memberSeq를 기준으로 ScheduleFriendInfo를 정렬하며, 순서가 없는 경우는 뒤쪽에 배치

## 🌱 관련 이슈
- close #

## 📌 작업 내용 및 특이사항
- 

## 📝 참고사항
- 

## 📚 기타
-